### PR TITLE
Improves Ep. Numbering

### DIFF
--- a/resources/lib/WonderfulSubsBrowser.py
+++ b/resources/lib/WonderfulSubsBrowser.py
@@ -126,7 +126,7 @@ class WonderfulSubsBrowser(BrowserBase):
 
         else:
             base.update({
-                "name": einfo["title"] if ((einfo["title"].split())[-1]).isdigit() else "Ep. %s (%s)" %(einfo["episode_number"], einfo["title"]), 
+                "name": einfo["title"] if "Episode" in einfo["title"] else "Ep. %s (%s)" %(einfo["episode_number"], einfo["title"]), 
                 "id": str(einfo["episode_number"]),
                 "url": "play/%s/%s/%d/%s" % (anime_url,
                                           "dub" if is_dubbed else "sub",


### PR DESCRIPTION
The original code didn't work on episodes that were named "... Part 2", shows like JoJo's Bizarre Adventures have a lot of episodes named like this. This makes the episode numbering on episodes that don't have ep numbers much better.