### PR TITLE
Change "A-B Listings" to "A-Z Listings"

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -3,7 +3,7 @@
 	<!-- Category strings -->
 	<string id="30000">Last Watched: </string>
 	<string id="30001">All</string>
-	<string id="30002">A-B Listing</string>
+	<string id="30002">A-Z Listing</string>
 	<string id="30003">Latest</string>
 	<string id="30004">Popular</string>
 	<string id="30005">Random</string>


### PR DESCRIPTION
Fixes 'A-B' typo