### PR TITLE
fix missing source and error

### DIFF
--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -204,6 +204,9 @@ def xbmc_add_dir(name, url, iconimage='', description='', draw_cm=None):
     return ok
 
 def _prefetch_play_link(link):
+    if isinstance(link, list):
+        link, subtitles = link
+
     if callable(link):
         link = link()
 
@@ -217,10 +220,10 @@ def _prefetch_play_link(link):
     return {
         "url": linkInfo.url,
         "headers": linkInfo.headers,
+        "subtitles": subtitles
     }
 
 def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None):
-    link, subtitles = link
     linkInfo = _prefetch_play_link(link)
     if not linkInfo:
         xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
@@ -230,8 +233,7 @@ def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None):
     if 'Content-Type' in linkInfo['headers']:
         item.setProperty('mimetype', linkInfo['headers']['Content-Type'])
 
-    if subtitles:
-        item.setSubtitles([subtitles])
+    item.setSubtitles([linkInfo.get('subtitles')])
 
     # Run any mimetype hook
     item = hook_mimetype.trigger(linkInfo['headers']['Content-Type'], item)

--- a/resources/lib/ui/embed_extractor.py
+++ b/resources/lib/ui/embed_extractor.py
@@ -82,7 +82,7 @@ def __extract_wonderfulsubs(url, content, referer=None):
 
 def __extract_rapidvideo(url, page_content, referer=None):
     soup = BeautifulSoup(page_content, 'html.parser')
-    results = map(lambda x: (x['label'], x['src'], None),
+    results = map(lambda x: (x['label'], x['src']),
                   soup.select('source'))
     return results
 

--- a/resources/lib/ui/embed_extractor.py
+++ b/resources/lib/ui/embed_extractor.py
@@ -82,7 +82,7 @@ def __extract_wonderfulsubs(url, content, referer=None):
 
 def __extract_rapidvideo(url, page_content, referer=None):
     soup = BeautifulSoup(page_content, 'html.parser')
-    results = map(lambda x: (x['label'], x['src']),
+    results = map(lambda x: (x['label'], x['src'], None),
                   soup.select('source'))
     return results
 

--- a/resources/lib/ui/utils.py
+++ b/resources/lib/ui/utils.py
@@ -52,13 +52,19 @@ def fetch_sources(sources, dialog, raise_exceptions=False, autoplay=False,
             if autoplay and sortBy is not None:
                 fetched_urls = sortBy(fetched_urls)
                 item = fetched_urls[0]
-                item = (item[0], item[1], item[2], name)
+                item = (item[0],
+                        item[1],
+                        item[2] if item[2:] else None,
+                        name)
                 if len(fetched_urls):
                     return dict([_format_source(0, item)])
 
             # X[0] => Label, X[1] => Url
             valid_urls = filter(lambda x: x[1] != None, fetched_urls)
-            total_urls += map(lambda x: (x[0], x[1], x[2], name), valid_urls)
+            total_urls += map(lambda x: (x[0],
+                                         x[1],
+                                         x[2] if x[2:] else None,
+                                         name), valid_urls)
             dialog.update(int(i * factor))
         except Exception, e:
             print "[*E*] Skiping %s because Exception at parsing" % name


### PR DESCRIPTION
forgot to refactor ~~rapidvideo~~ utilis code in pr #87 (for sources that don't have subtitle links) causing missing source and error:
```
link, subtitles = link        
TypeError: 'NoneType' object is not iterable
```
my bad