### PR TITLE
Add 'episode' mediatype to episode items

### DIFF
--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -183,7 +183,7 @@ def xbmc_add_player_item(name, url, iconimage='', description='', draw_cm=None):
     cm = draw_cm(addon_url, name) if draw_cm is not None else []
 
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
-    liz.setInfo('video', infoLabels={ "Title": name, "Plot": description })
+    liz.setInfo('video', infoLabels={ "Title": name, "Plot": description, "Mediatype": "episode" })
     liz.setProperty("fanart_image", __settings__.getAddonInfo('path') + "/fanart.jpg")
     liz.setProperty("Video", "true")
     liz.setProperty("IsPlayable", "true")


### PR DESCRIPTION
Sometimes the plot/description text for an episode is too big for the UI space on Kodi and becomes truncated.  
Setting the mediatype infolabel of episode items to the value 'episode' makes Kodi show a "Information" context-menu item on them, which leads to a screen where you can read the plot text in full.