### PR TITLE
Add 'List Sources' context menu

### DIFF
--- a/default.py
+++ b/default.py
@@ -248,7 +248,7 @@ def PLAY(payload, params):
     anime_url, flavor = anime_url.rsplit("/", 1)
     is_dubbed = True if "dub" == flavor else False
     name, image = _BROWSER.get_anime_metadata(anime_url, is_dubbed)
-    sources = _BROWSER.get_episode_sources(anime_url, is_dubbed, season, episode)    
+    sources = _BROWSER.get_episode_sources(anime_url, is_dubbed, season, episode)
     force_list_sources = ('sources' in params)
     autoplay = control.getSetting('autoplay') == 'true' and not force_list_sources
 
@@ -269,7 +269,7 @@ def PLAY(payload, params):
 
 @route('gogo_play/*')
 def GOGO_PLAY(payload, params):
-    sources = GogoAnimeBrowser().get_episode_sources(payload)    
+    sources = GogoAnimeBrowser().get_episode_sources(payload)
     force_list_sources = ('sources' in params)
     autoplay = control.getSetting('autoplay') == 'true' and not force_list_sources
 

--- a/default.py
+++ b/default.py
@@ -242,8 +242,12 @@ def SEARCH_ALT(payload, params):
 
 @route('list_sources/*')
 def LIST_SOURCES(payload, params):
-    control.set_property('list_sources', '1')
-    control.xbmc.executebuiltin('PlayMedia('+payload+')')
+    control.set_property('list_sources', '1')   
+    xbmc = control.xbmc
+    title = xbmc.getInfoLabel('ListItem.Title')
+    item = control.xbmcgui.ListItem(title)
+    item.setInfo("video", {"Title": title, "Plot": xbmc.getInfoLabel('ListItem.Plot'), "Mediatype": "episode"})    
+    xbmc.Player().play(item=payload, listitem=item)
 
 @route('play/*')
 def PLAY(payload, params):
@@ -255,8 +259,7 @@ def PLAY(payload, params):
     name, image = _BROWSER.get_anime_metadata(anime_url, is_dubbed)
     sources = _BROWSER.get_episode_sources(anime_url, is_dubbed, season, episode)
 
-    force_list_sources = (control.get_property('list_sources') is not None)
-    if force_list_sources:
+    if control.get_property('list_sources'):
         control.set_property('list_sources', '')
         autoplay = False
     else:
@@ -273,16 +276,14 @@ def PLAY(payload, params):
     control.play_source(s.get_video_link(),
                         watchlist_update(episode, kitsu_id),
                         on_stopped,
-                        on_percent if 'true' in control.getSetting('watchlist.percentbool') else None,
-                        force_list_sources
+                        on_percent if 'true' in control.getSetting('watchlist.percentbool') else None
                         )
 
 @route('gogo_play/*')
 def GOGO_PLAY(payload, params):
     sources = GogoAnimeBrowser().get_episode_sources(payload)
     
-    force_list_sources = (control.get_property('list_sources') is not None)
-    if force_list_sources:
+    if control.get_property('list_sources'):
         control.set_property('list_sources', '')
         autoplay = False
     else:
@@ -295,7 +296,7 @@ def GOGO_PLAY(payload, params):
         'notfound': control.lang(30103),
     })
 
-    control.play_source(s.get_video_link(), None, None, None, force_list_sources)
+    control.play_source(s.get_video_link())
 
 @route('')
 def LIST_MENU(payload, params):

--- a/default.py
+++ b/default.py
@@ -240,6 +240,11 @@ def SEARCH_ALT(payload, params):
 
     return control.draw_items(search_res)
 
+@route('list_sources/*')
+def LIST_SOURCES(payload, params):
+    control.set_property('list_sources', '1')
+    xbmc.executebuiltin('PlayMedia('+payload+')')
+
 @route('play/*')
 def PLAY(payload, params):
     anime_url, kitsu_id = payload.rsplit("/", 1)
@@ -249,8 +254,13 @@ def PLAY(payload, params):
     is_dubbed = True if "dub" == flavor else False
     name, image = _BROWSER.get_anime_metadata(anime_url, is_dubbed)
     sources = _BROWSER.get_episode_sources(anime_url, is_dubbed, season, episode)
-    force_list_sources = ('sources' in params)
-    autoplay = control.getSetting('autoplay') == 'true' and not force_list_sources
+
+    force_list_sources = (control.get_property('list_sources') is not None)
+    if force_list_sources:
+        control.set_property('list_sources', '')
+        autoplay = False
+    else:
+        autoplay = (control.getSetting('autoplay') == 'true')
 
     s = SourcesList(sorted(sources.items()), autoplay, sortResultsByRes, {
         'title': control.lang(30100),
@@ -270,8 +280,13 @@ def PLAY(payload, params):
 @route('gogo_play/*')
 def GOGO_PLAY(payload, params):
     sources = GogoAnimeBrowser().get_episode_sources(payload)
-    force_list_sources = ('sources' in params)
-    autoplay = control.getSetting('autoplay') == 'true' and not force_list_sources
+    
+    force_list_sources = (control.get_property('list_sources') is not None)
+    if force_list_sources:
+        control.set_property('list_sources', '')
+        autoplay = False
+    else:
+        autoplay = (control.getSetting('autoplay') == 'true')
 
     s = SourcesList(sorted(sources.items()), autoplay, sortResultsByRes, {
         'title': control.lang(30100),

--- a/default.py
+++ b/default.py
@@ -243,7 +243,7 @@ def SEARCH_ALT(payload, params):
 @route('list_sources/*')
 def LIST_SOURCES(payload, params):
     control.set_property('list_sources', '1')
-    xbmc.executebuiltin('PlayMedia('+payload+')')
+    xbmc.executebuiltin('PlayMedia('+control.addon_url(payload)+')')
 
 @route('play/*')
 def PLAY(payload, params):

--- a/default.py
+++ b/default.py
@@ -248,8 +248,9 @@ def PLAY(payload, params):
     anime_url, flavor = anime_url.rsplit("/", 1)
     is_dubbed = True if "dub" == flavor else False
     name, image = _BROWSER.get_anime_metadata(anime_url, is_dubbed)
-    sources = _BROWSER.get_episode_sources(anime_url, is_dubbed, season, episode)
-    autoplay = True if 'true' in control.getSetting('autoplay') else False
+    sources = _BROWSER.get_episode_sources(anime_url, is_dubbed, season, episode)    
+    force_list_sources = ('sources' in params)
+    autoplay = control.getSetting('autoplay') == 'true' and not force_list_sources
 
     s = SourcesList(sorted(sources.items()), autoplay, sortResultsByRes, {
         'title': control.lang(30100),
@@ -262,13 +263,15 @@ def PLAY(payload, params):
     control.play_source(s.get_video_link(),
                         watchlist_update(episode, kitsu_id),
                         on_stopped,
-                        on_percent if 'true' in control.getSetting('watchlist.percentbool') else None
+                        on_percent if 'true' in control.getSetting('watchlist.percentbool') else None,
+                        force_list_sources
                         )
 
 @route('gogo_play/*')
 def GOGO_PLAY(payload, params):
-    sources = GogoAnimeBrowser().get_episode_sources(payload)
-    autoplay = True if 'true' in control.getSetting('autoplay') else False
+    sources = GogoAnimeBrowser().get_episode_sources(payload)    
+    force_list_sources = ('sources' in params)
+    autoplay = control.getSetting('autoplay') == 'true' and not force_list_sources
 
     s = SourcesList(sorted(sources.items()), autoplay, sortResultsByRes, {
         'title': control.lang(30100),
@@ -277,7 +280,7 @@ def GOGO_PLAY(payload, params):
         'notfound': control.lang(30103),
     })
 
-    control.play_source(s.get_video_link())
+    control.play_source(s.get_video_link(), None, None, None, force_list_sources)
 
 @route('')
 def LIST_MENU(payload, params):

--- a/default.py
+++ b/default.py
@@ -243,7 +243,7 @@ def SEARCH_ALT(payload, params):
 @route('list_sources/*')
 def LIST_SOURCES(payload, params):
     control.set_property('list_sources', '1')
-    xbmc.executebuiltin('PlayMedia('+payload+')')
+    control.xbmc.executebuiltin('PlayMedia('+payload+')')
 
 @route('play/*')
 def PLAY(payload, params):

--- a/default.py
+++ b/default.py
@@ -243,7 +243,7 @@ def SEARCH_ALT(payload, params):
 @route('list_sources/*')
 def LIST_SOURCES(payload, params):
     control.set_property('list_sources', '1')
-    xbmc.executebuiltin('PlayMedia('+control.addon_url(payload)+')')
+    xbmc.executebuiltin('PlayMedia('+payload+')')
 
 @route('play/*')
 def PLAY(payload, params):

--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -11,10 +11,10 @@ try:
 except:
     import storageserverdummy as StorageServer
 
-__settings__ = xbmcaddon.Addon(ADDON_NAME)
+__settings__ = xbmcaddon.Addon()
 __language__ = __settings__.getLocalizedString
 
-HANDLE=int(sys.argv[1])
+HANDLE = int(sys.argv[1])
 ADDON_NAME = __settings__.getAddonInfo('id')
 CACHE = StorageServer.StorageServer("%s.animeinfo" % ADDON_NAME, 24)
 

--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -181,6 +181,7 @@ def xbmc_add_player_item(name, url, iconimage='', description='', draw_cm=None):
     ok=True
     u=addon_url(url)
     cm = draw_cm(addon_url, name) if draw_cm is not None else []
+    cm.append(("List Sources", "PlayMedia("+u+"?sources=1)"))
 
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo('video', infoLabels={ "Title": name, "Plot": description, "Mediatype": "episode" })
@@ -223,7 +224,7 @@ def _prefetch_play_link(link):
         "subtitles": subtitles
     }
 
-def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None):
+def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None, force_list_sources=False):
     linkInfo = _prefetch_play_link(link)
     if not linkInfo:
         xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
@@ -232,6 +233,16 @@ def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None):
     item = xbmcgui.ListItem(path=linkInfo['url'])
     if 'Content-Type' in linkInfo['headers']:
         item.setProperty('mimetype', linkInfo['headers']['Content-Type'])
+        
+    if force_list_sources:
+        item.setInfo(
+            "video",
+            {
+                "Title": xbmc.getInfoLabel("ListItem.Title"),
+                "Plot": xbmc.getInfoLabel("ListItem.Plot"),
+                "Mediatype": "episode"
+            }
+        )
 
     item.setSubtitles([linkInfo.get('subtitles')])
 

--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -189,7 +189,7 @@ def xbmc_add_player_item(name, url, iconimage='', description='', draw_cm=None):
     ok=True
     u=addon_url(url)
     cm = draw_cm(addon_url, name) if draw_cm is not None else []
-    cm.append(("List Sources", "RunPlugin(%s)" % addon_url("list_sources/" + url)))
+    cm.append(("List Sources", "RunPlugin(%s)" % addon_url("list_sources/"+u)))
 
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo('video', infoLabels={ "Title": name, "Plot": description, "Mediatype": "episode" })

--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -232,7 +232,7 @@ def _prefetch_play_link(link):
         "subtitles": subtitles
     }
 
-def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None, force_list_sources=False):
+def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None):
     linkInfo = _prefetch_play_link(link)
     if not linkInfo:
         xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
@@ -241,10 +241,6 @@ def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None, fo
     item = xbmcgui.ListItem(path=linkInfo['url'])
     if 'Content-Type' in linkInfo['headers']:
         item.setProperty('mimetype', linkInfo['headers']['Content-Type'])
-        
-    if force_list_sources:
-        item.setInfo("video", {"Title": xbmc.getInfoLabel("ListItem.Title"),
-            "Plot": xbmc.getInfoLabel("ListItem.Plot"), "Mediatype": "episode"})
 
     item.setSubtitles([linkInfo.get('subtitles')])
 

--- a/resources/lib/ui/control.py
+++ b/resources/lib/ui/control.py
@@ -1,4 +1,3 @@
-import re
 import sys
 import xbmc
 import xbmcaddon
@@ -12,10 +11,11 @@ try:
 except:
     import storageserverdummy as StorageServer
 
-HANDLE=int(sys.argv[1])
-ADDON_NAME = re.findall('plugin:\/\/([\w\d\.]+)\/', sys.argv[0])[0]
 __settings__ = xbmcaddon.Addon(ADDON_NAME)
 __language__ = __settings__.getLocalizedString
+
+HANDLE=int(sys.argv[1])
+ADDON_NAME = __settings__.getAddonInfo('id')
 CACHE = StorageServer.StorageServer("%s.animeinfo" % ADDON_NAME, 24)
 
 class hook_mimetype(object):
@@ -143,6 +143,14 @@ def multiselect_dialog(title, _list):
         return xbmcgui.Dialog().multiselect(title, _list)
     return None
 
+def set_property(name, value):
+    window = xbmcgui.Window(xbmcgui.getCurrentWindowId())
+    return window.setProperty(name, value)
+
+def get_property(name):
+    window = xbmcgui.Window(xbmcgui.getCurrentWindowId())
+    return window.getProperty(name)
+
 def clear_settings(dialog):
     confirm = dialog
     if confirm == 0:
@@ -181,7 +189,7 @@ def xbmc_add_player_item(name, url, iconimage='', description='', draw_cm=None):
     ok=True
     u=addon_url(url)
     cm = draw_cm(addon_url, name) if draw_cm is not None else []
-    cm.append(("List Sources", "PlayMedia("+u+"?sources=1)"))
+    cm.append(("List Sources", "RunPlugin(%s)" % addon_url("list_sources/" + url)))
 
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo('video', infoLabels={ "Title": name, "Plot": description, "Mediatype": "episode" })
@@ -235,14 +243,8 @@ def play_source(link, on_episode_done=None, on_stopped=None, on_percent=None, fo
         item.setProperty('mimetype', linkInfo['headers']['Content-Type'])
         
     if force_list_sources:
-        item.setInfo(
-            "video",
-            {
-                "Title": xbmc.getInfoLabel("ListItem.Title"),
-                "Plot": xbmc.getInfoLabel("ListItem.Plot"),
-                "Mediatype": "episode"
-            }
-        )
+        item.setInfo("video", {"Title": xbmc.getInfoLabel("ListItem.Title"),
+            "Plot": xbmc.getInfoLabel("ListItem.Plot"), "Mediatype": "episode"})
 
     item.setSubtitles([linkInfo.get('subtitles')])
 


### PR DESCRIPTION
I like to use the autoplay ("Automatically play first result") setting, it's great.  

On rare cases that autoplayed source doesn't work (it times-out etc.), so instead of going back to the add-on settings to disable autoplay, with this new context menu item you can play that episode as if autoplay was turned off, it will list its sources so another source can be chosen.