### PR TITLE
Allow Last Watched As a Widget

### DIFF
--- a/default.py
+++ b/default.py
@@ -18,6 +18,8 @@ LASTWATCHED_URL_KEY = "%s.url" % LASTWATCHED_KEY
 LASTWATCHED_IMAGE_KEY = "%s.image" % LASTWATCHED_KEY
 HISTORY_DELIM = ";"
 
+Home = xbmcgui.Window(10000)
+
 MENU_ITEMS = [
     (control.lang(30001), "anichart_airing", ''),
     (control.lang(30002), "all", ''),
@@ -43,6 +45,8 @@ def _add_last_watched():
         control.getSetting(LASTWATCHED_URL_KEY),
         control.getSetting(LASTWATCHED_IMAGE_KEY)
     ))
+    
+    Home.setProperty('LastWatched', control.getSetting(LASTWATCHED_URL_KEY))
 
 def __set_last_watched(url, is_dubbed, name, image):
     control.setSetting(LASTWATCHED_URL_KEY, 'animes/%s/%s' %(url, "dub" if is_dubbed else "sub"))


### PR DESCRIPTION
Hello!

Sorry, this is one of my first PR’s requests. 

I created this to give users the ability to point a widget or menu/submenu to the Last Watched option in WonderfulSubs by pointing the action to `plugin://plugin.video.wonderfulsubs/$INFO[Window(Home).Property(LastWatched)]`

This allows the widget path to update every time the addon is opened. 

This is probably not the most efficient or best way to integrate this. If you have a better way before you’d like it to be merged, let me know!